### PR TITLE
Prefer JNA

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,8 +46,10 @@ val scalacheckDep     = "org.scalacheck"                %% "scalacheck"         
 val jolDep            = "org.openjdk.jol"                % "jol-core"                         % "0.9"
 val asmDep            = "org.scala-lang.modules"         % "scala-asm"                        % versionProps("scala-asm.version")
 val jlineDep          = "org.jline"                      % "jline"                            % versionProps("jline.version")
-val jansiDep          = "org.fusesource.jansi"           % "jansi"                            % versionProps("jansi.version")
-val jlineDeps         = Seq(jlineDep, jansiDep)
+val jlineTerminalDep  = "org.jline"                      % "jline-terminal"                   % versionProps("jline.version")
+val jlineJnaDep       = "org.jline"                      % "jline-terminal-jna"               % versionProps("jline.version")
+val jnaDep            = "net.java.dev.jna"               % "jna"                              % versionProps("jna.version")
+val jlineDeps         = Seq(jlineDep, jlineJnaDep)
 val testInterfaceDep  = "org.scala-sbt"                  % "test-interface"                   % "1.0"
 val diffUtilsDep      = "com.googlecode.java-diff-utils" % "diffutils"                        % "1.3.0"
 
@@ -574,7 +576,7 @@ lazy val compiler = configureAsSubproject(project)
                             |org.jline.style.*;resolution:=optional
                             |org.jline.terminal;resolution:=optional
                             |org.jline.terminal.impl;resolution:=optional
-                            |org.jline.terminal.impl.jansi.*;resolution:=optional
+                            |org.jline.terminal.impl.jna.*;resolution:=optional
                             |org.jline.terminal.spi;resolution:=optional
                             |org.jline.utils;resolution:=optional
                             |scala.*;version="$${range;[==,=+);$${ver}}"
@@ -1118,10 +1120,14 @@ lazy val dist = (project in file("dist"))
     packageBin in Compile := {
       val targetDir = (buildDirectory in ThisBuild).value / "pack" / "lib"
       val jlineJAR = findJar((dependencyClasspath in Compile).value, jlineDep).get.data
-      val jansiJAR = findJar((dependencyClasspath in Compile).value, jansiDep).get.data
+      val jlineTerminalJAR = findJar((dependencyClasspath in Compile).value, jlineTerminalDep).get.data
+      val jlineJnaJAR = findJar((dependencyClasspath in Compile).value, jlineJnaDep).get.data
+      val jnaJAR = findJar((dependencyClasspath in Compile).value, jnaDep).get.data
       val mappings = Seq(
         (jlineJAR, targetDir / "jline.jar"),
-        (jansiJAR, targetDir / "jansi.jar"),
+        (jlineTerminalJAR, targetDir / "jline-terminal.jar"),
+        (jlineJnaJAR, targetDir / "jline-terminal-jna.jar"),
+        (jnaJAR, targetDir / "jna.jar"),
       )
       IO.copy(mappings, CopyOptions() withOverwrite true)
       targetDir

--- a/build.sbt
+++ b/build.sbt
@@ -46,10 +46,8 @@ val scalacheckDep     = "org.scalacheck"                %% "scalacheck"         
 val jolDep            = "org.openjdk.jol"                % "jol-core"                         % "0.9"
 val asmDep            = "org.scala-lang.modules"         % "scala-asm"                        % versionProps("scala-asm.version")
 val jlineDep          = "org.jline"                      % "jline"                            % versionProps("jline.version")
-val jlineTerminalDep  = "org.jline"                      % "jline-terminal"                   % versionProps("jline.version")
-val jlineJnaDep       = "org.jline"                      % "jline-terminal-jna"               % versionProps("jline.version")
 val jnaDep            = "net.java.dev.jna"               % "jna"                              % versionProps("jna.version")
-val jlineDeps         = Seq(jlineDep, jlineJnaDep)
+val jlineDeps         = Seq(jlineDep, jnaDep)
 val testInterfaceDep  = "org.scala-sbt"                  % "test-interface"                   % "1.0"
 val diffUtilsDep      = "com.googlecode.java-diff-utils" % "diffutils"                        % "1.3.0"
 
@@ -1120,13 +1118,9 @@ lazy val dist = (project in file("dist"))
     packageBin in Compile := {
       val targetDir = (buildDirectory in ThisBuild).value / "pack" / "lib"
       val jlineJAR = findJar((dependencyClasspath in Compile).value, jlineDep).get.data
-      val jlineTerminalJAR = findJar((dependencyClasspath in Compile).value, jlineTerminalDep).get.data
-      val jlineJnaJAR = findJar((dependencyClasspath in Compile).value, jlineJnaDep).get.data
       val jnaJAR = findJar((dependencyClasspath in Compile).value, jnaDep).get.data
       val mappings = Seq(
         (jlineJAR, targetDir / "jline.jar"),
-        (jlineTerminalJAR, targetDir / "jline-terminal.jar"),
-        (jlineJnaJAR, targetDir / "jline-terminal-jna.jar"),
         (jnaJAR, targetDir / "jna.jar"),
       )
       IO.copy(mappings, CopyOptions() withOverwrite true)

--- a/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
+++ b/src/repl-frontend/scala/tools/nsc/interpreter/jline/Reader.scala
@@ -54,8 +54,7 @@ object Reader {
 
     System.setProperty(LineReader.PROP_SUPPORT_PARSEDLINE, java.lang.Boolean.TRUE.toString())
 
-    //val terminal = TerminalBuilder.builder().build()
-    val terminal  = TerminalBuilder.terminal() // defaults for now
+    val terminal = TerminalBuilder.builder().jna(true).build()
     val completer = new Completion(completion)
     val parser    = new ReplParser(repl)
     val history   = new DefaultHistory

--- a/versions.properties
+++ b/versions.properties
@@ -7,5 +7,7 @@ starr.version=2.13.1
 # Other usages:
 #  - scala-asm: jar content included in scala-compiler
 scala-asm.version=7.3.1-scala-1
+
+# jna.version must be updated together with jline-terminal-jna
 jline.version=3.14.0
-jansi.version=1.18
+jna.version=5.3.1


### PR DESCRIPTION
Ref https://github.com/scala/scala-dev/issues/678

https://github.com/jline/jline3#jansi-vs-jna says

> On the Windows platform, relying on native calls is mandatory, so you need to have either Jansi or JNA library in your classpath along with the `jline-terminal-jansi` or `jline-terminal-jna` jar.

When I tested on Windows 7 or Windows 10 using `sbt console` I got "WARNING: Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)" and key input also didn't work. (This could be more to do with sbt). I am guessing that Jansi used by sbt itself maybe interfering with Jansi that gets loaded from the compiler. Normally these duplicates are resolved by creating a sandbox ClassLoader, but maybe it doesn't exactly work for native libraries loaded into the same process.

When I switched to using JNA the console worked ok at least for sbt 1.3.8.

### notes

To avoid the interference of dependencies between repl and sbt, maybe sbt needs to switch to forking to a fresh JVM for console, or at least provide an option to do so.