### PR TITLE
Vector{3..6}.prependedAll updates {len12..len12345}

### DIFF
--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -417,11 +417,11 @@ private final class Vector1[+A](_data1: Arr1) extends VectorImpl[A](_data1) {
   protected[immutable] def vectorSlice(idx: Int): Array[_ <: AnyRef] = prefix1
   protected[immutable] def vectorSlicePrefixLength(idx: Int): Int = prefix1.length
 
-  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] = {
-    val data1b = prepend1IfSpace(prefix1, prefix)
-    if(data1b ne null) new Vector1(data1b)
-    else super.prependedAll0(prefix, k)
-  }
+  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] =
+    prepend1IfSpace(prefix1, prefix) match {
+      case null => super.prependedAll0(prefix, k)
+      case data1b => new Vector1(data1b)
+    }
 
   override protected[this] def appendedAll0[B >: A](suffix: collection.IterableOnce[B], k: Int): Vector[B] = {
     val data1b = append1IfSpace(prefix1, suffix)
@@ -512,11 +512,17 @@ private final class Vector2[+A](_prefix1: Arr1, private[immutable] val len1: Int
     case 2 => length0
   }
 
-  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] = {
-    val prefix1b = prepend1IfSpace(prefix1, prefix)
-    if(prefix1b ne null) copy(prefix1 = prefix1b, len1 = len1-prefix1.length+prefix1b.length, length0 = length0-prefix1.length+prefix1b.length)
-    else super.prependedAll0(prefix, k)
-  }
+  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] =
+    prepend1IfSpace(prefix1, prefix) match {
+      case null => super.prependedAll0(prefix, k)
+      case prefix1b =>
+        val diff = prefix1b.length - prefix1.length
+        copy(prefix1 = prefix1b,
+             len1    = len1 + diff,
+             length0 = length0 + diff,
+        )
+    }
+
   override protected[this] def appendedAll0[B >: A](suffix: collection.IterableOnce[B], k: Int): Vector[B] = {
     val suffix1b = append1IfSpace(suffix1, suffix)
     if(suffix1b ne null) copy(suffix1 = suffix1b, length0 = length0-suffix1.length+suffix1b.length)
@@ -632,10 +638,11 @@ private final class Vector3[+A](_prefix1: Arr1, private[immutable] val len1: Int
     prepend1IfSpace(prefix1, prefix) match {
       case null => super.prependedAll0(prefix, k)
       case prefix1b =>
+        val diff = prefix1b.length - prefix1.length
         copy(prefix1 = prefix1b,
-             len1    = len1 - prefix1.length + prefix1b.length,
-             len12   = len12 - prefix1.length + prefix1b.length,
-             length0 = length0 - prefix1.length + prefix1b.length,
+             len1    = len1 + diff,
+             len12   = len12 + diff,
+             length0 = length0 + diff,
         )
     }
 
@@ -774,10 +781,12 @@ private final class Vector4[+A](_prefix1: Arr1, private[immutable] val len1: Int
     prepend1IfSpace(prefix1, prefix) match {
       case null => super.prependedAll0(prefix, k)
       case prefix1b =>
+        val diff = prefix1b.length - prefix1.length
         copy(prefix1 = prefix1b,
-             len1    = len1 - prefix1.length + prefix1b.length,
-             len12   = len12 - prefix1.length + prefix1b.length,
-             length0 = length0 - prefix1.length + prefix1b.length,
+             len1    = len1 + diff,
+             len12   = len12 + diff,
+             len123  = len123 + diff,
+             length0 = length0 + diff,
         )
     }
 
@@ -932,11 +941,19 @@ private final class Vector5[+A](_prefix1: Arr1, private[immutable] val len1: Int
     case 8 => length0
   }
 
-  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] = {
-    val prefix1b = prepend1IfSpace(prefix1, prefix)
-    if(prefix1b ne null) copy(prefix1 = prefix1b, len1 = len1-prefix1.length+prefix1b.length, length0 = length0-prefix1.length+prefix1b.length)
-    else super.prependedAll0(prefix, k)
-  }
+  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] =
+    prepend1IfSpace(prefix1, prefix) match {
+      case null => super.prependedAll0(prefix, k)
+      case prefix1b =>
+        val diff = prefix1b.length - prefix1.length
+        copy(prefix1 = prefix1b,
+          len1    = len1 + diff,
+          len12   = len12 + diff,
+          len123  = len123 + diff,
+          len1234 = len1234 + diff,
+          length0 = length0 + diff,
+        )
+    }
 
   override protected[this] def appendedAll0[B >: A](suffix: collection.IterableOnce[B], k: Int): Vector[B] = {
     val suffix1b = append1IfSpace(suffix1, suffix)
@@ -1109,11 +1126,20 @@ private final class Vector6[+A](_prefix1: Arr1, private[immutable] val len1: Int
     case 10 => length0
   }
 
-  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] = {
-    val prefix1b = prepend1IfSpace(prefix1, prefix)
-    if(prefix1b ne null) copy(prefix1 = prefix1b, len1 = len1-prefix1.length+prefix1b.length, length0 = length0-prefix1.length+prefix1b.length)
-    else super.prependedAll0(prefix, k)
-  }
+  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] =
+    prepend1IfSpace(prefix1, prefix) match {
+      case null => super.prependedAll0(prefix, k)
+      case prefix1b =>
+        val diff = prefix1b.length - prefix1.length
+        copy(prefix1 = prefix1b,
+          len1     = len1 + diff,
+          len12    = len12 + diff,
+          len123   = len123 + diff,
+          len1234  = len1234 + diff,
+          len12345 = len12345 + diff,
+          length0  = length0 + diff,
+        )
+    }
 
   override protected[this] def appendedAll0[B >: A](suffix: collection.IterableOnce[B], k: Int): Vector[B] = {
     val suffix1b = append1IfSpace(suffix1, suffix)

--- a/src/library/scala/collection/immutable/Vector.scala
+++ b/src/library/scala/collection/immutable/Vector.scala
@@ -628,11 +628,17 @@ private final class Vector3[+A](_prefix1: Arr1, private[immutable] val len1: Int
     case 4 => length0
   }
 
-  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] = {
-    val prefix1b = prepend1IfSpace(prefix1, prefix)
-    if(prefix1b ne null) copy(prefix1 = prefix1b, len1 = len1-prefix1.length+prefix1b.length, length0 = length0-prefix1.length+prefix1b.length)
-    else super.prependedAll0(prefix, k)
-  }
+  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] =
+    prepend1IfSpace(prefix1, prefix) match {
+      case null => super.prependedAll0(prefix, k)
+      case prefix1b =>
+        copy(prefix1 = prefix1b,
+             len1    = len1 - prefix1.length + prefix1b.length,
+             len12   = len12 - prefix1.length + prefix1b.length,
+             length0 = length0 - prefix1.length + prefix1b.length,
+        )
+    }
+
   override protected[this] def appendedAll0[B >: A](suffix: collection.IterableOnce[B], k: Int): Vector[B] = {
     val suffix1b = append1IfSpace(suffix1, suffix)
     if(suffix1b ne null) copy(suffix1 = suffix1b, length0 = length0-suffix1.length+suffix1b.length)
@@ -764,11 +770,16 @@ private final class Vector4[+A](_prefix1: Arr1, private[immutable] val len1: Int
     case 6 => length0
   }
 
-  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] = {
-    val prefix1b = prepend1IfSpace(prefix1, prefix)
-    if(prefix1b ne null) copy(prefix1 = prefix1b, len1 = len1-prefix1.length+prefix1b.length, length0 = length0-prefix1.length+prefix1b.length)
-    else super.prependedAll0(prefix, k)
-  }
+  override protected[this] def prependedAll0[B >: A](prefix: collection.IterableOnce[B], k: Int): Vector[B] =
+    prepend1IfSpace(prefix1, prefix) match {
+      case null => super.prependedAll0(prefix, k)
+      case prefix1b =>
+        copy(prefix1 = prefix1b,
+             len1    = len1 - prefix1.length + prefix1b.length,
+             len12   = len12 - prefix1.length + prefix1b.length,
+             length0 = length0 - prefix1.length + prefix1b.length,
+        )
+    }
 
   override protected[this] def appendedAll0[B >: A](suffix: collection.IterableOnce[B], k: Int): Vector[B] = {
     val suffix1b = append1IfSpace(suffix1, suffix)

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -439,10 +439,8 @@ class VectorTest {
     val (pre, suf) = v.splitAt(1)
     val v2 = suf.prependedAll(pre)
     validateDebug(v2)
-    // Validation failed: assertion failed: sum of slice lengths (1024) at prefix2 should be equal to prefix length (1023)
-    // [error] Vector3(lengths=[32, 1023, 9215, 9984, 10000])
     assertEquals(10000, v.last)
-    assertEquals(10000, v2(v2.length-1)) // ArrayIndexOutOfBoundsException
+    assertEquals(10000, v2(v2.length-1))
     assertEquals(1024, v2(1023))
   }
   @Test def `t12598b bad index on prependedAll`: Unit = {
@@ -450,10 +448,8 @@ class VectorTest {
     val (pre, suf) = v.splitAt(1)
     val v2 = suf.prependedAll(pre)
     validateDebug(v2)
-    // Validation failed: assertion failed: sum of slice lengths (1024) at prefix2 should be equal to prefix length (1023)
-    // [error] Vector3(lengths=[32, 1023, 9215, 9984, 10000])
-    assertEquals(10000, v.last)
-    assertEquals(10000, v2(v2.length-1)) // ArrayIndexOutOfBoundsException
+    assertEquals(1000000, v.last)
+    assertEquals(1000000, v2(v2.length-1))
     assertEquals(1024, v2(1023))
   }
 }

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -439,8 +439,10 @@ class VectorTest {
     val (pre, suf) = v.splitAt(1)
     val v2 = suf.prependedAll(pre)
     validateDebug(v2)
+    // Validation failed: assertion failed: sum of slice lengths (1024) at prefix2 should be equal to prefix length (1023)
+    // [error] Vector3(lengths=[32, 1023, 9215, 9984, 10000])
     assertEquals(10000, v.last)
-    assertEquals(10000, v2(v2.length-1))
+    assertEquals(10000, v2(v2.length-1)) // ArrayIndexOutOfBoundsException
     assertEquals(1024, v2(1023))
   }
   @Test def `t12598b bad index on prependedAll`: Unit = {
@@ -448,8 +450,10 @@ class VectorTest {
     val (pre, suf) = v.splitAt(1)
     val v2 = suf.prependedAll(pre)
     validateDebug(v2)
+    // Validation failed: assertion failed: sum of slice lengths (1024) at prefix2 should be equal to prefix length (1023)
+    // [error] Vector3(lengths=[32, 1023, 9215, 9984, 10000])
     assertEquals(1000000, v.last)
-    assertEquals(1000000, v2(v2.length-1))
+    assertEquals(1000000, v2(v2.length-1)) // ArrayIndexOutOfBoundsException
     assertEquals(1024, v2(1023))
   }
 }

--- a/test/junit/scala/collection/immutable/VectorTest.scala
+++ b/test/junit/scala/collection/immutable/VectorTest.scala
@@ -46,7 +46,7 @@ class VectorTest {
   }
 
   @Test
-  def hasCorrectAppenedAndPrependedAll(): Unit = {
+  def hasCorrectAppendedAndPrependedAll(): Unit = {
     val els = Vector(1 to 1000: _*)
 
     for (i <- 0 until els.size) {
@@ -432,6 +432,29 @@ class VectorTest {
   @Test def testAppendWithTinyLhs(): Unit = {
     (1 to 1000000).foldLeft(Vector.empty[Int]) { (v, i) => Vector(i) ++ v }
     (1 to 1000000).foldLeft(Vector.empty[Int]) { (v, i) => v.prependedAll(Vector(i)) }
+  }
+
+  @Test def `t12598 bad index on prependedAll`: Unit = {
+    val v = Vector.from(1 to 10000)
+    val (pre, suf) = v.splitAt(1)
+    val v2 = suf.prependedAll(pre)
+    validateDebug(v2)
+    // Validation failed: assertion failed: sum of slice lengths (1024) at prefix2 should be equal to prefix length (1023)
+    // [error] Vector3(lengths=[32, 1023, 9215, 9984, 10000])
+    assertEquals(10000, v.last)
+    assertEquals(10000, v2(v2.length-1)) // ArrayIndexOutOfBoundsException
+    assertEquals(1024, v2(1023))
+  }
+  @Test def `t12598b bad index on prependedAll`: Unit = {
+    val v = Vector.from(1 to 1000000)
+    val (pre, suf) = v.splitAt(1)
+    val v2 = suf.prependedAll(pre)
+    validateDebug(v2)
+    // Validation failed: assertion failed: sum of slice lengths (1024) at prefix2 should be equal to prefix length (1023)
+    // [error] Vector3(lengths=[32, 1023, 9215, 9984, 10000])
+    assertEquals(10000, v.last)
+    assertEquals(10000, v2(v2.length-1)) // ArrayIndexOutOfBoundsException
+    assertEquals(1024, v2(1023))
   }
 }
 


### PR DESCRIPTION
I hope it's okay I just grabbed your PR and continued in it.

This takes your solution (to update `len12` in `Vector3.prependedAll0`) and applies it to all `Vector{..6}` classes and lengths up to `len12345`.

fixes [#12598](https://github.com/scala/bug/issues/12598)